### PR TITLE
feature: add BillAndReset

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ ln -s ~/timelog ~/bin/timelog
 
 For a list of EntryTypes and their arguments, see `tctypes.py`.
 
+## Additional Features
+
+**BillAndReset** — Place `BillAndReset("30-04-2020", "RE-2026-0042 – Invoice created")` in your entries to mark a billing point. It prints the total billable hours accumulated since the last reset (or contract start) and then resets all hour counters so the next billing period starts fresh.
+
 ## Examples
 
 Look in `./tests` for a more complete example.

--- a/tests/timelog_bill_and_reset
+++ b/tests/timelog_bill_and_reset
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import sys
+
+sys.path.append("../timecount")
+
+
+from timecount import process
+from timecount.tctypes import (
+    EmploymentContract,
+    Balance,
+    BillAndReset,
+    Day,
+    HoliDay,
+    SickDay,
+    VacationDay,
+)
+
+# fmt: off
+# Example: BillAndReset prints the accumulated contract hours/over-hours at
+# the point of invoicing and resets the counters so the next billing period
+# starts fresh.
+entries = [
+    Day("01-04-2020", (12.30, 20.00), (20.30, 01.15), "Configure Workstation"),
+    Day("02-04-2020", (14.30, 00.30), "Configure Workstation"),
+    Day("03-04-2020", (10.30, 15.00), "Configure Workstation"),
+    Day("06-04-2020", (10.00, 14.30), (17.00, 22.15), "Pair Programming Daniel."),
+
+    # Issue invoice RE-2026-0042 after the first week – reset hour counters.
+    BillAndReset("06-04-2020", "RE-2026-0042 – Rechnung erstellt"),
+
+    Day("07-04-2020", (10.30, 14.30), (15.30, 21.45), "Pair Programming Daniel."),
+    Day("08-04-2020", (09.30, 14.30), (15.00, 19.15), "BrowserStack validation; Laptop setup."),
+    Day("09-04-2020", (11.00, 15.00), (19.30, 22.00), "BrowserStack device list; Meeting; Try test automation."),
+    HoliDay("10-04-2020", (12.00, 13.00), "Karfreitag; Tooling"),
+    Day("11-04-2020", (11.00, 14.00), (21.15, 00.00), "Tooling, BrowserStack Testing."),
+    Day("12-04-2020", (11.15, 13.15), "System Setup; Tooling;"),
+
+    # Issue a second invoice after the second week.
+    BillAndReset("12-04-2020", "RE-2026-0043 – Rechnung erstellt"),
+
+    Day("14-04-2020", (11.00, 14.00), (15.30, 18.30), "Tooling; SlackMeetings; BrowserStack;"),
+    Day("15-04-2020", (10.30, 14.15), (15.30, 19.30), "BrowserStack Issue Support;"),
+]
+
+process(entries)

--- a/timecount/lib.py
+++ b/timecount/lib.py
@@ -154,6 +154,14 @@ def print_contract_result(entry: EmploymentContract) -> None:
     print()
 
 
+def print_bill_and_reset_result(entry: BillAndReset, state: State) -> None:
+    a = f"{C.MONTH_SUM}BillAndReset{C.RS}"
+    d = f"{C.GREY}Date:{C.TIME}{entry.date_str}{C.RS}"
+    bill = f"{C.GREY}Billable:{C.OVER_GREEN}{delta_to_str(state.contract_total_hours)}{C.RS}"
+    n = f"{C.GREY}{entry.note}{C.RS}" if entry.note else ""
+    print(f"\n{a} {d} {bill} {n}{C.RS_ALL}\n")
+
+
 def print_balance_result(entry: Balance) -> None:
     a = f"{C.RED_TYPE}Balance    {C.GREY}"
     s = ""
@@ -317,6 +325,21 @@ def process(entries: List[Entry]) -> None:
             state.week_target_hours = entry.hours_per_week
 
             print_contract_result(entry)
+
+            continue
+
+        if isinstance(entry, BillAndReset):
+
+            print_bill_and_reset_result(entry, state)
+
+            state.contract_total_hours = timedelta(hours=0, minutes=0)
+            state.contract_over_hours = timedelta(hours=0, minutes=0)
+            state.week_total_hours = timedelta(hours=0, minutes=0)
+            state.week_over_hours = timedelta(hours=0, minutes=0)
+            state.month_total_hours = timedelta(hours=0, minutes=0)
+            state.month_over_hours = timedelta(hours=0, minutes=0)
+            state.year_total_hours = timedelta(hours=0, minutes=0)
+            state.year_over_hours = timedelta(hours=0, minutes=0)
 
             continue
 

--- a/timecount/tctypes.py
+++ b/timecount/tctypes.py
@@ -43,6 +43,12 @@ class Balance(Entry):
     note: str = ""
 
 
+@dataclass
+class BillAndReset(Entry):
+    date_str: str = ""
+    note: str = ""
+
+
 DayValues = Union[Tuple[float, float], str]
 
 


### PR DESCRIPTION
## useful for freelancers

<img width="1007" height="356" alt="image" src="https://github.com/user-attachments/assets/06567fd2-4e93-498a-a268-928c78c51cec" />


- Introduced BillAndReset class to manage billing points and reset hour counters.
- Added print functionality for BillAndReset results.
- Updated README with additional features section detailing BillAndReset usage.
- Created example test for BillAndReset functionality.